### PR TITLE
README: fix rustup script name

### DIFF
--- a/silicon/README.md
+++ b/silicon/README.md
@@ -125,7 +125,7 @@ have to hack the install script so it thinks that the machine is
 1. Install rustup
 
     ```
-    bash /tmp/rustup.sh --default-toolchain none
+    bash /tmp/rustup.rs --default-toolchain none
     ```
 
 1. Create a toolchain and make it the default:


### PR DESCRIPTION
This is a super minor change, but I noticed that `rustup.rs` is downloaded under that name but the instructions say to run it as `rustup.sh` without renaming it.